### PR TITLE
Switch PyPI publishing to OIDC

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - "v*" # Trigger on version tags
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build distribution 📦
@@ -36,6 +39,9 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     environment:
       name: pypi
     steps:
@@ -48,12 +54,15 @@ jobs:
       - name: Publish distribution 📦 to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
+          attestations: true
 
   publish-to-testpypi:
     name: Publish One Chat API 📦 to TestPyPI
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     environment:
       name: testpypi
     steps:
@@ -67,4 +76,4 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
-          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          attestations: true


### PR DESCRIPTION
## Summary
- request OIDC permissions for publish steps
- drop PyPI/TestPyPI passwords in favor of trusted publishing attestations
- align artifact actions to latest versions

## Testing
- not run (workflow change only)
